### PR TITLE
size parameter fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,4 +15,4 @@ Depends:
     scales
 Imports:
     grid
-RoxygenNote: 5.0.1
+RoxygenNote: 7.1.0

--- a/R/geom-km.R
+++ b/R/geom-km.R
@@ -61,38 +61,38 @@ GeomKmband <- ggplot2::ggproto("GeomKmband", Geom,
 #' @rdname geom_kmticks
 
 GeomKmticks <- ggplot2::ggproto("GeomKmticks", Geom,
-
-                       draw_group = function(data, scales, coordinates, ...) {
-
-                         showpoints <- data$n.censor > 0 & data$n.event == 0
-
-                         coordsp <- coordinates$transform(data, scales)[showpoints, , drop = FALSE]
-
-                         if(nrow(coordsp) == 0){
-                           grid::nullGrob()
-                         } else {
-                         grid::pointsGrob(
-                           coordsp$x, coordsp$y,
-                           pch = coordsp$shape,
-                           size = grid::unit(coordsp$size, "char"),
-                           gp = grid::gpar(
-                             col = coordsp$colour,
-                             fill = coordsp$fill,
-                             alpha = coordsp$alpha
-                           )
-                         )
-                         }
-
-                       },
-
-                       required_aes = c("x", "y"),
-                       non_missing_aes = c("size", "shape"),
-                       default_aes = ggplot2::aes(
-                         shape = 3, colour = "black", size = .75,
-                         alpha = 1, stroke = 0.5, fill = "black"
-                       ),
-                       draw_key = draw_key_point
-
+                                
+                                draw_group = function(data, scales, coordinates, ...) {
+                                  
+                                  showpoints <- data$n.censor > 0 & data$n.event == 0
+                                  
+                                  coordsp <- coordinates$transform(data, scales)[showpoints, , drop = FALSE]
+                                  
+                                  if(nrow(coordsp) == 0){
+                                    grid::nullGrob()
+                                  } else {
+                                    grid::pointsGrob(
+                                      coordsp$x, coordsp$y,
+                                      pch = coordsp$shape,
+                                      gp = grid::gpar(
+                                        col = coordsp$colour,
+                                        fill = coordsp$fill,
+                                        alpha = coordsp$alpha,
+                                        fontsize = coordsp$size *.pt
+                                      )
+                                    )
+                                  }
+                                  
+                                },
+                                
+                                required_aes = c("x", "y"),
+                                non_missing_aes = c("size", "shape"),
+                                default_aes = ggplot2::aes(
+                                  shape = 3, colour = "black", size = 3,
+                                  alpha = 1, stroke = 0.5, fill = "black"
+                                ),
+                                draw_key = draw_key_point
+                                
 )
 
 

--- a/man/geom_km.Rd
+++ b/man/geom_km.Rd
@@ -5,32 +5,43 @@
 \alias{GeomKm}
 \alias{geom_km}
 \title{Display Kaplan Meier Curve}
-\format{An object of class \code{GeomKm} (inherits from \code{Geom}, \code{ggproto}) of length 5.}
+\format{
+An object of class \code{GeomKm} (inherits from \code{Geom}, \code{ggproto}, \code{gg}) of length 5.
+}
 \usage{
 GeomKm
 
-geom_km(mapping = NULL, data = NULL, stat = "km", position = "identity",
-  show.legend = NA, inherit.aes = TRUE, na.rm = TRUE, ...)
+geom_km(
+  mapping = NULL,
+  data = NULL,
+  stat = "km",
+  position = "identity",
+  show.legend = NA,
+  inherit.aes = TRUE,
+  na.rm = TRUE,
+  ...
+)
 }
 \arguments{
-\item{mapping}{Set of aesthetic mappings created by \code{\link{aes}} or
-\code{\link{aes_}}. If specified and \code{inherit.aes = TRUE} (the
+\item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{aes()}} or
+\code{\link[ggplot2:aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
 default), it is combined with the default mapping at the top level of the
 plot. You must supply \code{mapping} if there is no plot mapping.}
 
 \item{data}{The data to be displayed in this layer. There are three
-   options:
+options:
 
-   If \code{NULL}, the default, the data is inherited from the plot
-   data as specified in the call to \code{\link{ggplot}}.
+If \code{NULL}, the default, the data is inherited from the plot
+data as specified in the call to \code{\link[ggplot2:ggplot]{ggplot()}}.
 
-   A \code{data.frame}, or other object, will override the plot
-   data. All objects will be fortified to produce a data frame. See
-   \code{\link{fortify}} for which variables will be created.
+A \code{data.frame}, or other object, will override the plot
+data. All objects will be fortified to produce a data frame. See
+\code{\link[ggplot2:fortify]{fortify()}} for which variables will be created.
 
-   A \code{function} will be called with a single argument,
-   the plot data. The return value must be a \code{data.frame.}, and
-   will be used as the layer data.}
+A \code{function} will be called with a single argument,
+the plot data. The return value must be a \code{data.frame}, and
+will be used as the layer data. A \code{function} can be created
+from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
 \item{stat}{The statistical transformation to use on the data for this
 layer, as a string.}
@@ -40,25 +51,25 @@ a call to a position adjustment function.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+It can also be a named logical vector to finely select the aesthetics to
+display.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
-the default plot specification, e.g. \code{\link{borders}}.}
+the default plot specification, e.g. \code{\link[ggplot2:borders]{borders()}}.}
 
-\item{na.rm}{If \code{FALSE} (the default), removes missing values with
-a warning.  If \code{TRUE} silently removes missing values.}
+\item{na.rm}{If \code{FALSE}, the default, missing values are removed with
+a warning. If \code{TRUE}, missing values are silently removed.}
 
-\item{...}{other arguments passed on to \code{\link{layer}}. These are
+\item{...}{Other arguments passed on to \code{\link[ggplot2:layer]{layer()}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like
-\code{color = "red"} or \code{size = 3}. They may also be parameters
+\code{colour = "red"} or \code{size = 3}. They may also be parameters
 to the paired geom/stat.}
 }
 \description{
 Kaplan Meier Curve
-
-Add a Kaplan-Meier survival curve
 }
 \section{Aesthetics}{
 
@@ -74,6 +85,7 @@ are in bold):
   \item \code{size}
 }
 }
+
 \examples{
 sex <- rbinom(250, 1, .5)
 df <- data.frame(time = exp(rnorm(250, mean = sex)), status = rbinom(250, 1, .75), sex = sex)
@@ -84,4 +96,3 @@ The default stat for this geom is \code{\link{stat_km}} see
   that documentation for more options to control the underlying statistical transformation.
 }
 \keyword{datasets}
-

--- a/man/geom_kmband.Rd
+++ b/man/geom_kmband.Rd
@@ -5,33 +5,43 @@
 \alias{GeomKmband}
 \alias{geom_kmband}
 \title{Display Kaplan Meier Curve}
-\format{An object of class \code{GeomKmband} (inherits from \code{Geom}, \code{ggproto}) of length 5.}
+\format{
+An object of class \code{GeomKmband} (inherits from \code{Geom}, \code{ggproto}, \code{gg}) of length 5.
+}
 \usage{
 GeomKmband
 
-geom_kmband(mapping = NULL, data = NULL, stat = "kmband",
-  position = "identity", show.legend = NA, inherit.aes = TRUE,
-  na.rm = TRUE, ...)
+geom_kmband(
+  mapping = NULL,
+  data = NULL,
+  stat = "kmband",
+  position = "identity",
+  show.legend = NA,
+  inherit.aes = TRUE,
+  na.rm = TRUE,
+  ...
+)
 }
 \arguments{
-\item{mapping}{Set of aesthetic mappings created by \code{\link{aes}} or
-\code{\link{aes_}}. If specified and \code{inherit.aes = TRUE} (the
+\item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{aes()}} or
+\code{\link[ggplot2:aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
 default), it is combined with the default mapping at the top level of the
 plot. You must supply \code{mapping} if there is no plot mapping.}
 
 \item{data}{The data to be displayed in this layer. There are three
-   options:
+options:
 
-   If \code{NULL}, the default, the data is inherited from the plot
-   data as specified in the call to \code{\link{ggplot}}.
+If \code{NULL}, the default, the data is inherited from the plot
+data as specified in the call to \code{\link[ggplot2:ggplot]{ggplot()}}.
 
-   A \code{data.frame}, or other object, will override the plot
-   data. All objects will be fortified to produce a data frame. See
-   \code{\link{fortify}} for which variables will be created.
+A \code{data.frame}, or other object, will override the plot
+data. All objects will be fortified to produce a data frame. See
+\code{\link[ggplot2:fortify]{fortify()}} for which variables will be created.
 
-   A \code{function} will be called with a single argument,
-   the plot data. The return value must be a \code{data.frame.}, and
-   will be used as the layer data.}
+A \code{function} will be called with a single argument,
+the plot data. The return value must be a \code{data.frame}, and
+will be used as the layer data. A \code{function} can be created
+from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
 \item{stat}{The statistical transformation to use on the data for this
 layer, as a string.}
@@ -41,25 +51,25 @@ a call to a position adjustment function.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+It can also be a named logical vector to finely select the aesthetics to
+display.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
-the default plot specification, e.g. \code{\link{borders}}.}
+the default plot specification, e.g. \code{\link[ggplot2:borders]{borders()}}.}
 
-\item{na.rm}{If \code{FALSE} (the default), removes missing values with
-a warning.  If \code{TRUE} silently removes missing values.}
+\item{na.rm}{If \code{FALSE}, the default, missing values are removed with
+a warning. If \code{TRUE}, missing values are silently removed.}
 
-\item{...}{other arguments passed on to \code{\link{layer}}. These are
+\item{...}{Other arguments passed on to \code{\link[ggplot2:layer]{layer()}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like
-\code{color = "red"} or \code{size = 3}. They may also be parameters
+\code{colour = "red"} or \code{size = 3}. They may also be parameters
 to the paired geom/stat.}
 }
 \description{
 Kaplan Meier Curve
-
-Add confidence bands to a Kaplan-Meier survival curve
 }
 \section{Aesthetics}{
 
@@ -75,6 +85,7 @@ are in bold):
   \item \code{size}
 }
 }
+
 \examples{
 sex <- rbinom(250, 1, .5)
 df <- data.frame(time = exp(rnorm(250, mean = sex)), status = rbinom(250, 1, .75), sex = sex)
@@ -85,4 +96,3 @@ The default stat for this geom is \code{\link{stat_kmband}} see
   that documentation for more options to control the underlying statistical transformation.
 }
 \keyword{datasets}
-

--- a/man/geom_kmticks.Rd
+++ b/man/geom_kmticks.Rd
@@ -5,33 +5,43 @@
 \alias{GeomKmticks}
 \alias{geom_kmticks}
 \title{Display tick marks on a Kaplan Meier curve}
-\format{An object of class \code{GeomKmticks} (inherits from \code{Geom}, \code{ggproto}) of length 6.}
+\format{
+An object of class \code{GeomKmticks} (inherits from \code{Geom}, \code{ggproto}, \code{gg}) of length 6.
+}
 \usage{
 GeomKmticks
 
-geom_kmticks(mapping = NULL, data = NULL, stat = "kmticks",
-  position = "identity", show.legend = NA, inherit.aes = TRUE,
-  na.rm = TRUE, ...)
+geom_kmticks(
+  mapping = NULL,
+  data = NULL,
+  stat = "kmticks",
+  position = "identity",
+  show.legend = NA,
+  inherit.aes = TRUE,
+  na.rm = TRUE,
+  ...
+)
 }
 \arguments{
-\item{mapping}{Set of aesthetic mappings created by \code{\link{aes}} or
-\code{\link{aes_}}. If specified and \code{inherit.aes = TRUE} (the
+\item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{aes()}} or
+\code{\link[ggplot2:aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
 default), it is combined with the default mapping at the top level of the
 plot. You must supply \code{mapping} if there is no plot mapping.}
 
 \item{data}{The data to be displayed in this layer. There are three
-   options:
+options:
 
-   If \code{NULL}, the default, the data is inherited from the plot
-   data as specified in the call to \code{\link{ggplot}}.
+If \code{NULL}, the default, the data is inherited from the plot
+data as specified in the call to \code{\link[ggplot2:ggplot]{ggplot()}}.
 
-   A \code{data.frame}, or other object, will override the plot
-   data. All objects will be fortified to produce a data frame. See
-   \code{\link{fortify}} for which variables will be created.
+A \code{data.frame}, or other object, will override the plot
+data. All objects will be fortified to produce a data frame. See
+\code{\link[ggplot2:fortify]{fortify()}} for which variables will be created.
 
-   A \code{function} will be called with a single argument,
-   the plot data. The return value must be a \code{data.frame.}, and
-   will be used as the layer data.}
+A \code{function} will be called with a single argument,
+the plot data. The return value must be a \code{data.frame}, and
+will be used as the layer data. A \code{function} can be created
+from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
 \item{stat}{The statistical transformation to use on the data for this
 layer, as a string.}
@@ -41,19 +51,21 @@ a call to a position adjustment function.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+It can also be a named logical vector to finely select the aesthetics to
+display.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
-the default plot specification, e.g. \code{\link{borders}}.}
+the default plot specification, e.g. \code{\link[ggplot2:borders]{borders()}}.}
 
-\item{na.rm}{If \code{FALSE} (the default), removes missing values with
-a warning.  If \code{TRUE} silently removes missing values.}
+\item{na.rm}{If \code{FALSE}, the default, missing values are removed with
+a warning. If \code{TRUE}, missing values are silently removed.}
 
-\item{...}{other arguments passed on to \code{\link{layer}}. These are
+\item{...}{Other arguments passed on to \code{\link[ggplot2:layer]{layer()}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like
-\code{color = "red"} or \code{size = 3}. They may also be parameters
+\code{colour = "red"} or \code{size = 3}. They may also be parameters
 to the paired geom/stat.}
 }
 \description{
@@ -75,6 +87,7 @@ are in bold):
   \item \code{size}
 }
 }
+
 \examples{
 sex <- rbinom(250, 1, .5)
 df <- data.frame(time = exp(rnorm(250, mean = sex)), status = rbinom(250, 1, .75), sex = sex)
@@ -85,4 +98,3 @@ The default stat for this geom is \code{\link{stat_kmticks}} see
   that documentation for more options to control the underlying statistical transformation.
 }
 \keyword{datasets}
-

--- a/man/stat_km.Rd
+++ b/man/stat_km.Rd
@@ -5,33 +5,47 @@
 \alias{StatKm}
 \alias{stat_km}
 \title{Adds a Kaplan Meier Estimate of Survival}
-\format{An object of class \code{StatKm} (inherits from \code{Stat}, \code{ggproto}) of length 4.}
+\format{
+An object of class \code{StatKm} (inherits from \code{Stat}, \code{ggproto}, \code{gg}) of length 4.
+}
 \usage{
 StatKm
 
-stat_km(mapping = NULL, data = NULL, geom = "km", position = "identity",
-  show.legend = NA, inherit.aes = TRUE, se = TRUE, trans = "identity",
-  firstx = 0, firsty = 1, type = "kaplan-meier", start.time = 0)
+stat_km(
+  mapping = NULL,
+  data = NULL,
+  geom = "km",
+  position = "identity",
+  show.legend = NA,
+  inherit.aes = TRUE,
+  se = TRUE,
+  trans = "identity",
+  firstx = 0,
+  firsty = 1,
+  type = "kaplan-meier",
+  start.time = 0
+)
 }
 \arguments{
-\item{mapping}{Set of aesthetic mappings created by \code{\link{aes}} or
-\code{\link{aes_}}. If specified and \code{inherit.aes = TRUE} (the
+\item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{aes()}} or
+\code{\link[ggplot2:aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
 default), it is combined with the default mapping at the top level of the
 plot. You must supply \code{mapping} if there is no plot mapping.}
 
 \item{data}{The data to be displayed in this layer. There are three
-   options:
+options:
 
-   If \code{NULL}, the default, the data is inherited from the plot
-   data as specified in the call to \code{\link{ggplot}}.
+If \code{NULL}, the default, the data is inherited from the plot
+data as specified in the call to \code{\link[ggplot2:ggplot]{ggplot()}}.
 
-   A \code{data.frame}, or other object, will override the plot
-   data. All objects will be fortified to produce a data frame. See
-   \code{\link{fortify}} for which variables will be created.
+A \code{data.frame}, or other object, will override the plot
+data. All objects will be fortified to produce a data frame. See
+\code{\link[ggplot2:fortify]{fortify()}} for which variables will be created.
 
-   A \code{function} will be called with a single argument,
-   the plot data. The return value must be a \code{data.frame.}, and
-   will be used as the layer data.}
+A \code{function} will be called with a single argument,
+the plot data. The return value must be a \code{data.frame}, and
+will be used as the layer data. A \code{function} can be created
+from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
 \item{geom}{The geometric object to use display the data}
 
@@ -40,12 +54,14 @@ a call to a position adjustment function.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+It can also be a named logical vector to finely select the aesthetics to
+display.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
-the default plot specification, e.g. \code{\link{borders}}.}
+the default plot specification, e.g. \code{\link[ggplot2:borders]{borders()}}.}
 
 \item{trans}{Transformation to apply to the survival probabilities. Defaults
 to "identity". Other options include "event", "cumhaz", "cloglog", or
@@ -82,6 +98,7 @@ are in bold):
   \item \code{size}
 }
 }
+
 \examples{
 sex <- rbinom(250, 1, .5)
 df <- data.frame(time = exp(rnorm(250, mean = sex)), status = rbinom(250, 1, .75), sex = sex)
@@ -100,4 +117,3 @@ p1 + stat_km(start.time = 5)
 
 }
 \keyword{datasets}
-

--- a/man/stat_kmband.Rd
+++ b/man/stat_kmband.Rd
@@ -5,35 +5,50 @@
 \alias{StatKmband}
 \alias{stat_kmband}
 \title{Adds confidence bands to a Kaplan Meier Estimate of Survival}
-\format{An object of class \code{StatKmband} (inherits from \code{Stat}, \code{ggproto}) of length 4.}
+\format{
+An object of class \code{StatKmband} (inherits from \code{Stat}, \code{ggproto}, \code{gg}) of length 4.
+}
 \usage{
 StatKmband
 
-stat_kmband(mapping = NULL, data = NULL, geom = "kmband",
-  position = "identity", show.legend = NA, inherit.aes = TRUE,
-  trans = "identity", firstx = 0, firsty = 1, type = "kaplan-meier",
-  error = "tsiatis", conf.type = "log", conf.lower = "usual",
-  start.time = 0, conf.int = 0.95)
+stat_kmband(
+  mapping = NULL,
+  data = NULL,
+  geom = "kmband",
+  position = "identity",
+  show.legend = NA,
+  inherit.aes = TRUE,
+  trans = "identity",
+  firstx = 0,
+  firsty = 1,
+  type = "kaplan-meier",
+  error = "tsiatis",
+  conf.type = "log",
+  conf.lower = "usual",
+  start.time = 0,
+  conf.int = 0.95
+)
 }
 \arguments{
-\item{mapping}{Set of aesthetic mappings created by \code{\link{aes}} or
-\code{\link{aes_}}. If specified and \code{inherit.aes = TRUE} (the
+\item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{aes()}} or
+\code{\link[ggplot2:aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
 default), it is combined with the default mapping at the top level of the
 plot. You must supply \code{mapping} if there is no plot mapping.}
 
 \item{data}{The data to be displayed in this layer. There are three
-   options:
+options:
 
-   If \code{NULL}, the default, the data is inherited from the plot
-   data as specified in the call to \code{\link{ggplot}}.
+If \code{NULL}, the default, the data is inherited from the plot
+data as specified in the call to \code{\link[ggplot2:ggplot]{ggplot()}}.
 
-   A \code{data.frame}, or other object, will override the plot
-   data. All objects will be fortified to produce a data frame. See
-   \code{\link{fortify}} for which variables will be created.
+A \code{data.frame}, or other object, will override the plot
+data. All objects will be fortified to produce a data frame. See
+\code{\link[ggplot2:fortify]{fortify()}} for which variables will be created.
 
-   A \code{function} will be called with a single argument,
-   the plot data. The return value must be a \code{data.frame.}, and
-   will be used as the layer data.}
+A \code{function} will be called with a single argument,
+the plot data. The return value must be a \code{data.frame}, and
+will be used as the layer data. A \code{function} can be created
+from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
 \item{geom}{The geometric object to use display the data}
 
@@ -42,12 +57,14 @@ a call to a position adjustment function.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+It can also be a named logical vector to finely select the aesthetics to
+display.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
-the default plot specification, e.g. \code{\link{borders}}.}
+the default plot specification, e.g. \code{\link[ggplot2:borders]{borders()}}.}
 
 \item{trans}{Transformation to apply to the survival probabilities. Defaults
 to "identity". Other options include "event", "cumhaz", "cloglog", or
@@ -88,6 +105,7 @@ are in bold):
   \item \code{size}
 }
 }
+
 \examples{
 sex <- rbinom(250, 1, .5)
 df <- data.frame(time = exp(rnorm(250, mean = sex)), status = rbinom(250, 1, .75), sex = sex)
@@ -103,4 +121,3 @@ p1 + stat_km() + stat_km(conf.type = "log-log")
 
 }
 \keyword{datasets}
-

--- a/man/stat_kmticks.Rd
+++ b/man/stat_kmticks.Rd
@@ -5,32 +5,43 @@
 \alias{StatKmticks}
 \alias{stat_kmticks}
 \title{Compute locations for tick marks}
-\format{An object of class \code{StatKmticks} (inherits from \code{Stat}, \code{ggproto}) of length 4.}
+\format{
+An object of class \code{StatKmticks} (inherits from \code{Stat}, \code{ggproto}, \code{gg}) of length 4.
+}
 \usage{
 StatKmticks
 
-stat_kmticks(mapping = NULL, data = NULL, geom = "kmticks",
-  position = "identity", show.legend = NA, inherit.aes = TRUE, trans, ...)
+stat_kmticks(
+  mapping = NULL,
+  data = NULL,
+  geom = "kmticks",
+  position = "identity",
+  show.legend = NA,
+  inherit.aes = TRUE,
+  trans,
+  ...
+)
 }
 \arguments{
-\item{mapping}{Set of aesthetic mappings created by \code{\link{aes}} or
-\code{\link{aes_}}. If specified and \code{inherit.aes = TRUE} (the
+\item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{aes()}} or
+\code{\link[ggplot2:aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
 default), it is combined with the default mapping at the top level of the
 plot. You must supply \code{mapping} if there is no plot mapping.}
 
 \item{data}{The data to be displayed in this layer. There are three
-   options:
+options:
 
-   If \code{NULL}, the default, the data is inherited from the plot
-   data as specified in the call to \code{\link{ggplot}}.
+If \code{NULL}, the default, the data is inherited from the plot
+data as specified in the call to \code{\link[ggplot2:ggplot]{ggplot()}}.
 
-   A \code{data.frame}, or other object, will override the plot
-   data. All objects will be fortified to produce a data frame. See
-   \code{\link{fortify}} for which variables will be created.
+A \code{data.frame}, or other object, will override the plot
+data. All objects will be fortified to produce a data frame. See
+\code{\link[ggplot2:fortify]{fortify()}} for which variables will be created.
 
-   A \code{function} will be called with a single argument,
-   the plot data. The return value must be a \code{data.frame.}, and
-   will be used as the layer data.}
+A \code{function} will be called with a single argument,
+the plot data. The return value must be a \code{data.frame}, and
+will be used as the layer data. A \code{function} can be created
+from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
 \item{geom}{The geometric object to use display the data}
 
@@ -39,12 +50,14 @@ a call to a position adjustment function.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+It can also be a named logical vector to finely select the aesthetics to
+display.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
-the default plot specification, e.g. \code{\link{borders}}.}
+the default plot specification, e.g. \code{\link[ggplot2:borders]{borders()}}.}
 
 \item{trans}{Transformation to apply to the survival probabilities. Defaults
 to "identity". Other options include "event", "cumhaz", "cloglog", or
@@ -58,8 +71,6 @@ a data.frame with additional columns: \item{x}{x in data}
 }
 \description{
 Tick marks are plotted where there are censoring times that are also not event times
-
-Adds tick marks to a Kaplan Meier Estimate of Survival
 }
 \details{
 This stat is for computing the tick marks for a Kaplan-Meier survival estimate for
@@ -83,6 +94,7 @@ are in bold):
   \item \code{size}
 }
 }
+
 \examples{
 sex <- rbinom(250, 1, .5)
 df <- data.frame(time = exp(rnorm(250, mean = sex)), status = rbinom(250, 1, .75), sex = sex)
@@ -94,4 +106,3 @@ ggplot(df, aes(time = time, status = status, color = factor(sex))) +
 \link{stat_km}
 }
 \keyword{datasets}
-


### PR DESCRIPTION
Hi there. I discovered your package today, because I am not quite happy about the functionality of ggsurvplot. 
First, amazing work!!! I love your geoms. I agree with you that having a dedicated `geom` is the better way. (https://github.com/tidyverse/ggplot2/issues/1080)
However, I have noticed that using `geom_kmticks`, using character as shapes (e.g. shape = "|" ) did not allow changing of the size. DIgging into your code and comparing it to geom_point, I found that including the size aesthetic into the grid::gpar object (as fontsize argument!) would allow the legend glyphs and the plotted points to be the same, and allow size control for any shape.